### PR TITLE
0.8.1 ハンバーガーメニューや、テンプレート動作を修正

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -328,5 +328,40 @@ function kanso_general_register_required_plugins() {
 	tgmpa( $plugins, $config );
 }
 
+
+/**
+ * どのページテンプレートを使うか判定する
+ *
+ * 戻り値 : content or sidebar
+ *
+ */
+function kns_get_template() {
 	
+	if( is_page_template( 'page-sidebar.php' ) ){
+		return 'sidebar';
+	}
+	
+	if( is_page_template( 'page-content.php' ) ){
+		return 'content';
+	}
+	
+	//デフォルトの場合
+	
+	if( is_front_page() ){
+		return 'content';   //指定がなければ、コンテンツのみを採用する
+	}
+	
+	if( is_home() ){
+		return 'content';   //投稿ページはサイドバーはないので、コンテンツレイアウトとして設定(headerで必要)
+	}
+	
+	// デフォルトレイアウト値を戻す
+	$options = get_option('kns_options');
+	if( isset( $options['kns_default_layout'] ) && ($options['kns_default_layout'] == 'sidebar') ){
+		return 'sidebar';
+	}
+	else{
+		return 'content';
+	}
+}
 

--- a/header.php
+++ b/header.php
@@ -62,10 +62,13 @@
 									) );
 								?>
 								<?php
-									if ( is_page_template( 'page-sidebar.php' ) ) {
+									
+									// ハンバーガーメニューの表示、非表示
+									// - page-sidebar.php が指定してある場合は非表示
+									// - デフォルトレイアウトでサイドバーが指定されている
+									// サイドバーが設定してある場合
+									if ( kns_get_template() == 'sidebar' ) {
 										$uk_visible = 'uk-hidden@m';
-									} else {
-										
 									}
 								?>
 			                    <ul class="uk-navbar-nav <?php echo $uk_visible; ?>">

--- a/page.php
+++ b/page.php
@@ -12,11 +12,7 @@
  * @package kanso-general
  */
 
-$options = get_option('kns_options');
-
-if( isset( $options['kns_default_layout'] ) 
-		&& ($options['kns_default_layout'] == 'sidebar')
-) {
+if ( kns_get_template() == 'sidebar' ) {
 	get_template_part('page','sidebar');
 }
 else {  // デフォルト

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: http://kansowp.toiee.jp/
 Author: toiee Lab
 Author URI: http://toiee.jp/
 Description: KANSO General は、できるだけ少ない設定、学習コストで、美しく、洗練され、オリジナリティがあるWebサイトを作るためのテーマです。シンプル・簡素 is best の精神で作られています。 詳細は、<a href="http://kansowp.toiee.jp/">http://kansowp.toiee.jp/</a>
-Version: 0.8
+Version: 0.8.1
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: kanso-general

--- a/theme.json
+++ b/theme.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.8",
+	"version": "0.8.1",
 	"details_url": "https://kansowp.toiee.jp/category/update/",
 	"download_url": "https://github.com/toiee-lab/kanso-general/archive/master.zip"
 }


### PR DESCRIPTION
ハンバーガーメニューをコンテンツの状態に合わせて、表示、非表示を正しく修正。

- ページテンプレートが指定されている場合、必ず従う
- デフォルトの場合（指定されていない場合）
    - FrontPage なら コンテンツレイアウト
    - is_home ならコンテンツレイアウト
    - KANSOのデフォルト設定に従う

このような仕様に修正